### PR TITLE
docker fix and update readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM node:argon
 
 RUN mkdir /app
 
-WORKDIR /app
+COPY . /app
 
 COPY package.json /app
 
-RUN npm install
+WORKDIR /app
 
-COPY . /app
+RUN npm install
 
 EXPOSE 8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: "2"
 
 services:
   web:
-    build: .
-    volumes:
-      - ./:/app
+    image: bigdoods/speckle
     ports:
       - "8080:8080"
     environment:
@@ -24,6 +22,6 @@ services:
      ports:
        - "27017:27017"
      environment:
-       - MONGO_INITDB_ROOT_USERNAME=reportsUser
-       - MONGO_INITDB_ROOT_PASSWORD=password
+       - MONGO_INITDB_ROOT_USERNAME=
+       - MONGO_INITDB_ROOT_PASSWORD=
        - MONGO_INITDB_DATABASE=speckle

--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,9 @@ This is the Speckle Server, which coordinates communications between the various
 
 1) Install [Docker](https://www.docker.com/products/overview) and [docker-compose](https://docs.docker.com/compose) to your host.
 
-2) Clone this repository and change your working path to this repository.
+2) Clone repository and change your working path to this repository.
 
-3) Skip to next step if you are happy to run your own mongo database with speckle.
-
-If you want to use a hosted mongodb, open docker-compose.yml and update the ENVIRONMENT section under web service with details of your mongo instance.
+3) If you want to use a hosted mongodb, open docker-compose.yml and update the ENVIRONMENT section under web service with details of your mongo instance.
 
 4) Run it! `$ docker-compose up`
 
@@ -40,7 +38,7 @@ It's forthcoming. [Do you want to help?](mailto:d.stefanescu@ucl.ac.uk)
 
 
 ## Credits
-Developed by Dimitrie A. Stefanescu [@idid](http://twitter.com/idid) / [UCL The Bartlett](https://www.ucl.ac.uk/bartlett/) / [InnoChain](http://innochain.net)
+Developed by Dimitrie A. Stefanescu [@idid](http://twitter.com/idid) / [UCL The Bartlett](https://www.ucl.ac.uk/bartlett/) / [InnoChain](http://innochain.net) / [Jenca](http://www.jenca.org)
 
 This project has received funding from the European Union’s Horizon 2020 research and innovation programme under the Marie Sklodowska-Curie grant agreement No 642877.
 


### PR DESCRIPTION
Some changes to make docker-compose work. Since last commit, the default config settings for the db was updated and as a result speckle could not authenticate with mongo. I also [pushed an image to dockerhub](https://hub.docker.com/r/bigdoods/speckle/) for speckle so that the user would not have to build each time.

Please clone and run <$docker-compose up -d> followed by a visit to localhost:8080 to test.

Also, I tidied up the docker section a bit in the readme and added myself to the contributors section :-)